### PR TITLE
Preserve test method exception when TearDown throws exception

### DIFF
--- a/GroboContainer.NUnitExtensions.Tests/ExecutionFailures/TestFailuresInDifferentPartsTest.cs
+++ b/GroboContainer.NUnitExtensions.Tests/ExecutionFailures/TestFailuresInDifferentPartsTest.cs
@@ -160,6 +160,18 @@ namespace GroboContainer.NUnitExtensions.Tests.ExecutionFailures
         }
     }
 
+    [Explicit("Intentionally fails with 'Error in FailureInTestAndTearDown_ExplicitTest.Test()' error and 'Error in AndB.TearDown()' error")]
+    [GroboTestFixture, AndATearDownFailure]
+    public class FailureInTestAndTearDown_ExplicitTest
+    {
+        [Test]
+        public void Test()
+        {
+            GroboTestMachineryTrace.Log($"{nameof(FailureInTestAndTearDown_ExplicitTest)}.Test()");
+            throw new InvalidOperationException($"Error in {nameof(FailureInTestAndTearDown_ExplicitTest)}.Test()");
+        }
+    }
+
     public class TestFailuresInDifferentPartsTest
     {
         /// <summary>
@@ -227,6 +239,22 @@ AndC.TearDown()
             var result = testResults[nameof(FailureInFieldInjection_ExplicitTest.Test)];
             result.Message.Should().Contain("GroboContainer.Impl.Exceptions.AmbiguousConstructorException");
             result.Output.Should().Be(@"FailureInFieldInjection_ExplicitTest.TestFixtureSetUp()
+");
+        }
+
+        [Test]
+        public void TestFailureInTestAndTearDown()
+        {
+            var testResults = TestRunner.RunTestClass<FailureInTestAndTearDown_ExplicitTest>();
+            var result = testResults[nameof(FailureInTestAndTearDown_ExplicitTest.Test)];
+            result.Message.Should().Contain($"Error in {nameof(FailureInTestAndTearDown_ExplicitTest)}.Test()").And.Contain("Error in AndB.TearDown()");
+            result.Output.Should().Be(@"AndC.SetUp()
+AndB.SetUp()
+AndA.SetUp()
+FailureInTestAndTearDown_ExplicitTest.Test()
+AndA.TearDown()
+AndB.TearDown()
+AndC.TearDown()
 ");
         }
     }

--- a/GroboContainer.NUnitExtensions/Impl/FailedTestException.cs
+++ b/GroboContainer.NUnitExtensions/Impl/FailedTestException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GroboContainer.NUnitExtensions.Impl
+{
+    public class FailedTestException : Exception
+    {
+        public FailedTestException(string message, string stackTrace)
+        {
+            Message = message;
+            StackTrace = stackTrace;
+        }
+
+        public override string Message { get; }
+
+        public override string StackTrace { get; }
+    }
+}

--- a/GroboContainer.NUnitExtensions/Impl/GroboTestAction.cs
+++ b/GroboContainer.NUnitExtensions/Impl/GroboTestAction.cs
@@ -15,6 +15,8 @@ using JetBrains.Annotations;
 
 using NUnit.Framework.Interfaces;
 
+using NUnitTestContext = NUnit.Framework.TestContext;
+
 namespace GroboContainer.NUnitExtensions.Impl
 {
     public static class GroboTestAction
@@ -130,9 +132,19 @@ namespace GroboContainer.NUnitExtensions.Impl
             }
             if (errors.Count > 0)
             {
+                var aggregateExceptionMessage = $"{errors.Count} TearDown methods failed.";
+
+                var testResult = NUnitTestContext.CurrentContext.Result;
+                if (testResult.Outcome.Status == TestStatus.Failed && testResult.Outcome.Site == FailureSite.Test)
+                {
+                    aggregateExceptionMessage = $"Test method and {errors.Count} TearDown method(s) failed.";
+                    errors.Insert(0, new FailedTestException(testResult.Message, testResult.StackTrace));
+                }
+
                 if (errors.Count == 1)
                     throw errors[0];
-                throw new AggregateException("After test methods failed.", errors);
+
+                throw new AggregateException(aggregateExceptionMessage, errors);
             }
         }
 


### PR DESCRIPTION
NUnit записывает сообщение и стектрейс брошенного в тесте исключения в TestResult, но если исключение также возникло в одном из TearDown-методов, оно перепишет инфу об исключении в тесте.

В случае, когда есть исключение и в тесте и хотя бы в одном из TearDown-методов, добавляем инфу об исключении из теста в AggregateException.