### PR TITLE
Заменил метод PrepForRemoting на ExceptionDispatchInfo.Capture

### DIFF
--- a/GroboContainer.NUnitExtensions/Impl/ExceptionExtensions.cs
+++ b/GroboContainer.NUnitExtensions/Impl/ExceptionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 using JetBrains.Annotations;
 
@@ -9,8 +10,7 @@ namespace GroboContainer.NUnitExtensions.Impl
     {
         public static void Rethrow([NotNull] this Exception exception)
         {
-            prepForRemotingMethodInfo.Invoke(exception, new object[0]);
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         public static void RethrowInnerException([NotNull] this TargetInvocationException exception)
@@ -18,7 +18,5 @@ namespace GroboContainer.NUnitExtensions.Impl
             exception.InnerException?.Rethrow();
             throw exception;
         }
-
-        private static readonly MethodInfo prepForRemotingMethodInfo = typeof(Exception).GetMethod("PrepForRemoting", BindingFlags.NonPublic | BindingFlags.Instance);
     }
 }


### PR DESCRIPTION
В текущей версии framework нет метода PrepForRemoting у класс Exception, поэтому все вызовы этого метода падают с исключением Object reference not set to an instance of an object.